### PR TITLE
投稿用テキストエリアの横幅を広げる

### DIFF
--- a/src/views/App.css
+++ b/src/views/App.css
@@ -56,7 +56,7 @@ button {
   margin-right: 1em;
 
   height: 5rem;
-  width: 15rem;
+  flex-grow: 1;
 }
 
 .note-block {


### PR DESCRIPTION
投稿用テキストエリアと投稿ボタンを合わせた横幅がタイムラインのノートと同様になるよう、投稿用テキストエリアの横幅を広げます。